### PR TITLE
Add LLVM back

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,8 +1,7 @@
 name = "VectorizationBase"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.21"
-
+version = "0.12.23"
 
 [deps]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"

--- a/Project.toml
+++ b/Project.toml
@@ -1,15 +1,18 @@
 name = "VectorizationBase"
 uuid = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 authors = ["Chris Elrod <elrodc@gmail.com>"]
-version = "0.12.22"
+version = "0.12.21"
+
 
 [deps]
 CpuId = "adafc99b-e345-5852-983c-f28acb93d879"
+LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
 CpuId = "0.2"
+LLVM = "1,2"
 julia = "1"
 
 [extras]

--- a/src/VectorizationBase.jl
+++ b/src/VectorizationBase.jl
@@ -1,7 +1,7 @@
 module VectorizationBase
 
 using LinearAlgebra, Libdl
-# const LLVM_SHOULD_WORK = Sys.ARCH !== :i686 && isone(length(filter(lib->occursin(r"LLVM\b", basename(lib)), Libdl.dllist())))
+const LLVM_SHOULD_WORK = Sys.ARCH !== :i686 && isone(length(filter(lib->occursin(r"LLVM\b", basename(lib)), Libdl.dllist())))
 
 # isfile(joinpath(@__DIR__, "cpu_info.jl")) || throw("File $(joinpath(@__DIR__, "cpu_info.jl")) does not exist. Please run `using Pkg; Pkg.build()`.")
 
@@ -241,7 +241,7 @@ include("static.jl")
 include("vectorizable.jl")
 include("strideprodcsestridedpointers.jl")
 @static if Sys.ARCH === :x86_64 || Sys.ARCH === :i686
-    @static if Base.libllvm_version >= v"8"
+    @static if Base.libllvm_version >= v"8" && LLVM_SHOULD_WORK
         include("cpu_info_x86_llvm.jl")
     else
         include("cpu_info_x86_cpuid.jl")

--- a/src/cpu_info_x86_llvm.jl
+++ b/src/cpu_info_x86_llvm.jl
@@ -1,7 +1,7 @@
 
-import CpuId
+import CpuId, LLVM
 
-let features = filter(ext -> (m = match(r"\d", ext); isnothing(m) ? true : m.offset != 2 ) , split(unsafe_string(ccall(:LLVMGetHostCPUFeatures, Cstring, ())), ','))
+let features = filter(ext -> (m = match(r"\d", ext); isnothing(m) ? true : m.offset != 2 ) , split(unsafe_string(LLVM.API.LLVMGetHostCPUFeatures()), ','))
     offsetnottwo(::Nothing) = true
     offsetnottwo(m::RegexMatch) = m.offset != 2
 

--- a/src/cpu_info_x86_llvm.jl
+++ b/src/cpu_info_x86_llvm.jl
@@ -1,7 +1,8 @@
 
 import CpuId, LLVM
 
-let features = filter(ext -> (m = match(r"\d", ext); isnothing(m) ? true : m.offset != 2 ) , split(unsafe_string(LLVM.API.LLVMGetHostCPUFeatures()), ','))
+let features_cstring = LLVM.API.LLVMGetHostCPUFeatures()
+    features = filter(ext -> (m = match(r"\d", ext); isnothing(m) ? true : m.offset != 2 ) , split(unsafe_string(features_cstring), ','))
     offsetnottwo(::Nothing) = true
     offsetnottwo(m::RegexMatch) = m.offset != 2
 
@@ -25,6 +26,7 @@ let features = filter(ext -> (m = match(r"\d", ext); isnothing(m) ? true : m.off
     for ext ∈ features
         @eval const $(Symbol(replace(Base.Unicode.uppercase(ext[2:end]), r"\." => "_"))) = $(first(ext) == '+')
     end
+    Libc.free(features_cstring)
 end
 
 const FMA3 = FMA


### PR DESCRIPTION
https://github.com/maleadt/LLVM.jl/blob/e23db0c29c452d181e7a4b803928f799451d8976/src/util.jl#L73-L80

This PR reverts https://github.com/chriselrod/VectorizationBase.jl/commit/d319b68e27dfde7747db0b7d9d725f25d57ac182. LLVM.jl uses `@runtime_ccall`. Just using `ccall` is not robust enough. That commit causes Windows to error sometimes.