### PR TITLE
Prevent generated functions from being compiled before `__init__()` has been called

### DIFF
--- a/src/VectorizationBase.jl
+++ b/src/VectorizationBase.jl
@@ -391,7 +391,6 @@ function assert_init_has_finished()
 end
 
 function __init__()
-    _init_has_started[] = true
     set_features!()
     try
         TOPOLOGY.topology = Hwloc.topology_load();

--- a/src/VectorizationBase.jl
+++ b/src/VectorizationBase.jl
@@ -383,8 +383,12 @@ const TOPOLOGY = Topology()
 include("precompile.jl")
 _precompile_()
 
-const _init_has_started = Ref(false)
 const _init_has_finished = Ref(false)
+
+function assert_init_has_finished()
+    _init_has_finished[] || throw(ErrorException("bad stuff happened"))
+    return nothing
+end
 
 function __init__()
     _init_has_started[] = true

--- a/src/VectorizationBase.jl
+++ b/src/VectorizationBase.jl
@@ -383,7 +383,11 @@ const TOPOLOGY = Topology()
 include("precompile.jl")
 _precompile_()
 
+const _init_has_started = Ref(false)
+const _init_has_finished = Ref(false)
+
 function __init__()
+    _init_has_started[] = true
     set_features!()
     try
         TOPOLOGY.topology = Hwloc.topology_load();
@@ -394,6 +398,8 @@ function __init__()
             Proceeding with generic topology assumptions. This may result in reduced performance.
         """
     end
+    _init_has_finished[] = true
+    return nothing
 end
 
 

--- a/src/cache_inclusivity.jl
+++ b/src/cache_inclusivity.jl
@@ -40,5 +40,7 @@ function dynamic_cache_inclusivity()::NTuple{4,Bool}
     t
 end
 
-@generated cache_inclusivity() = dynamic_cache_inclusivity()
-
+@generated function cache_inclusivity()
+    assert_init_has_finished()
+    return dynamic_cache_inclusivity()
+end

--- a/src/cpu_info.jl
+++ b/src/cpu_info.jl
@@ -41,7 +41,10 @@ dynamic_register_count() = Sys.ARCH === :i686 ? 8 : (has_feature("x86_64_avx512f
 dynamic_has_opmask_registers() = has_feature("x86_64_avx512f")
 
 # This is terrible, I know. Please let me know if you have a better solution
-@generated fma_fast() = dynamic_fma_fast()
+@generated function fma_fast()
+    _init_has_finished[] || throw(ErrorException("bad stuff happened"))
+    return dynamic_fma_fast()
+end
 @generated has_opmask_registers() = dynamic_has_opmask_registers()
 
 @generated sregister_size() = Expr(:call, Expr(:curly, :StaticInt, dynamic_register_size()))

--- a/src/cpu_info.jl
+++ b/src/cpu_info.jl
@@ -42,7 +42,7 @@ dynamic_has_opmask_registers() = has_feature("x86_64_avx512f")
 
 # This is terrible, I know. Please let me know if you have a better solution
 @generated function fma_fast()
-    _init_has_finished[] || throw(ErrorException("bad stuff happened"))
+    assert_init_has_finished()
     return dynamic_fma_fast()
 end
 @generated has_opmask_registers() = dynamic_has_opmask_registers()

--- a/src/cpu_info.jl
+++ b/src/cpu_info.jl
@@ -45,15 +45,26 @@ dynamic_has_opmask_registers() = has_feature("x86_64_avx512f")
     assert_init_has_finished()
     return dynamic_fma_fast()
 end
-@generated has_opmask_registers() = dynamic_has_opmask_registers()
 
-@generated sregister_size() = Expr(:call, Expr(:curly, :StaticInt, dynamic_register_size()))
-@generated sregister_count() = Expr(:call, Expr(:curly, :StaticInt, dynamic_register_count()))
-@generated ssimd_integer_register_size() = Expr(:call, Expr(:curly, :StaticInt, dynamic_integer_register_size()))
+@generated function has_opmask_registers()
+    assert_init_has_finished()
+    return dynamic_has_opmask_registers()
+end
+@generated function sregister_size() 
+    assert_init_has_finished()
+    return Expr(:call, Expr(:curly, :StaticInt, dynamic_register_size()))
+end
+
+@generated function sregister_count()
+    assert_init_has_finished()
+    return Expr(:call, Expr(:curly, :StaticInt, dynamic_register_count()))
+end
+
+@generated function ssimd_integer_register_size()
+    assert_init_has_finished()
+    return Expr(:call, Expr(:curly, :StaticInt, dynamic_integer_register_size()))
+end
 
 register_size() = convert(Int, sregister_size())
 register_count() = convert(Int, sregister_count())
 simd_integer_register_size() = convert(Int, ssimd_integer_register_size())
-
-
-

--- a/src/topology.jl
+++ b/src/topology.jl
@@ -13,6 +13,7 @@ function count_attr(topology::Hwloc.Object, attr)
 end
 
 @generated function sattr_count(::Val{attr}) where {attr}
+    assert_init_has_finished()
     topology = TOPOLOGY.topology
     topology === nothing && return nothing
     count = count_attr(topology, attr)
@@ -82,13 +83,23 @@ function define_cache(N)
     )
 end
 
-@generated cache_description(::Union{Val{N},StaticInt{N}}) where {N} = define_cache(N)
+@generated function cache_description(::Union{Val{N},StaticInt{N}}) where {N}
+    assert_init_has_finished()
+    return define_cache(N)
+end
 
-@generated scache_size(::Union{Val{N},StaticInt{N}}) where {N} = Expr(:call, Expr(:curly, :StaticInt, something(define_cache(N).size, 0)))
+@generated function scache_size(::Union{Val{N},StaticInt{N}}) where {N}
+    assert_init_has_finished()
+    return Expr(:call, Expr(:curly, :StaticInt, something(define_cache(N).size, 0)))
+end
+                         
 cache_size(::Union{Val{N},StaticInt{N}}) where {N} = convert(Int, scache_size(Val(N)))
 
-@generated scacheline_size(::Union{Val{N},StaticInt{N}}) where {N} = Expr(:call, Expr(:curly, :StaticInt, something(define_cache(N).linesize, 64)))
+@generated function scacheline_size(::Union{Val{N},StaticInt{N}}) where {N}
+    assert_init_has_finished()
+    return Expr(:call, Expr(:curly, :StaticInt, something(define_cache(N).linesize, 64)))
+end
+
 cacheline_size(::Union{Val{N},StaticInt{N}}) where {N} = convert(Int, scacheline_size(Val(N)))
 scacheline_size() = scacheline_size(Val(1))
 cacheline_size() = cacheline_size(Val(1))
-


### PR DESCRIPTION
This is truly evil, and we should not merge it. I'm just curious if it will even work.