### PR TITLE
Add combined tile store and transposed store and load

### DIFF
--- a/src/VectorizationBase.jl
+++ b/src/VectorizationBase.jl
@@ -58,10 +58,10 @@ struct VecUnroll{N,W,T,V<:Union{NativeTypes,AbstractSIMD{W,T}}} <: AbstractSIMD{
     data::Tuple{V,Vararg{V,N}}
     # @inline VecUnroll{N,W,T,V}(data::Tuple{V,Vararg{V,N}}) where {N,W,T,V<:AbstractSIMDVector{W,T}} = new{N,W,T,V}(data)
     # @inline (VecUnroll(data::Tuple{V,Vararg{V,N}})::VecUnroll{N,W,T,Vec{W,T}}) where {N,W,T,V<:AbstractSIMDVector{W,T}} = new{N,W,T,V}(data)
-    @inline (VecUnroll(data::Tuple{V,Vararg{V,N}})::VecUnroll{N,W,T,V}) where {N,W,T,V<:AbstractSIMDVector{W,T}} = new{N,W,T,V}(data)
+    @inline (VecUnroll(data::Tuple{V,Vararg{V,N}})::VecUnroll{N,W,T,V}) where {N,W,T,V<:AbstractSIMD{W,T}} = new{N,W,T,V}(data)
+    # @inline (VecUnroll(data::Tuple{V,Vararg{V,N}})::VecUnroll{N,W,T,V}) where {N,W,T,V<:AbstractSIMDVector{W,T}} = new{N,W,T,V}(data)
     @inline (VecUnroll(data::Tuple{T,Vararg{T,N}})::VecUnroll{N,T,T}) where {N,T<:NativeTypes} = new{N,1,T,T}(data)
 end
-
 # const AbstractSIMD{W,T} = Union{AbstractSIMDVector{W,T},VecUnroll{<:Any,W,T}}
 const VecOrScalar = Union{AbstractSIMDVector,NativeTypes}
 const NativeTypesV = Union{AbstractSIMD,NativeTypes,StaticInt}

--- a/src/llvm_intrin/vbroadcast.jl
+++ b/src/llvm_intrin/vbroadcast.jl
@@ -22,6 +22,14 @@
         Vec(llvmcall($instrs, _Vec{$W,$T}, Tuple{}))
     end
 end
+@generated function _vundef(::StaticInt{W}, ::Type{T}) where {W,T<:NativeTypes}
+    typ = LLVM_TYPES[T]
+    instrs = "ret <$W x $typ> undef"
+    quote
+        $(Expr(:meta,:inline))
+        Vec(llvmcall($instrs, _Vec{$W,$T}, Tuple{}))
+    end
+end
 @generated function _vbroadcast(::StaticInt{W}, s::_T, ::StaticInt{RS}) where {W,_T<:NativeTypes,RS}
     isone(W) && return :s
     if _T <: Integer && sizeof(_T) * W > RS


### PR DESCRIPTION
These need tests, but I at least tested the stores with a few LoopVectorization functions.
I haven't tested the transposed load for unrolls at all, yet.

Both should have actual tests here instead of just in LoopVectorization.
If LoopVectorization's tests didn't take so long, it may be worth running some integration tests and checking how well VectorizationBase is actually covered that way.